### PR TITLE
close file descriptors

### DIFF
--- a/fs.h
+++ b/fs.h
@@ -339,6 +339,7 @@ size_t
 fs_size (char *path) {
   size_t size;
   FILE *file = fs_open(path, "r");
+  if (NULL == file) return -1;
   fseek(file, 0, SEEK_END);
   size = ftell(file);
   fs_close(file);
@@ -361,13 +362,17 @@ fs_fsize (FILE *file) {
 char *
 fs_read (char *path) {
   FILE *file = fs_open(path, "r");
-  return fs_fread(file);
+  if (NULL == file) return NULL;
+  char *data = fs_fread(file);
+  fclose(file);
+  return data;
 }
 
 
 char *
 fs_nread (char *path, int len) {
   FILE *file = fs_open(path, "r");
+  if (NULL == file) return NULL;
   char *buffer = fs_fnread(file, len);
   fs_close(file);
   return buffer;
@@ -398,7 +403,11 @@ fs_write (char *path, char *buffer) {
 
 int
 fs_nwrite (char *path, char *buffer, int len) {
-  return fs_fnwrite(fs_open(path, "w"), buffer, len);
+  FILE *file = fs_open(path, "w");
+  if (NULL == file) return -1;
+  int result = fs_fnwrite(file, buffer, len);
+  fclose(file);
+  return result;
 }
 
 


### PR DESCRIPTION
and gracefully report errors when `fs_open` fails

before:

```

$ valgrind --track-fds=yes ./test-fs
==94811== Memcheck, a memory error detector
==94811== Copyright (C) 2002-2012, and GNU GPL'd, by Julian Seward et al.
==94811== Using Valgrind-3.8.1 and LibVEX; rerun with -h for copyright info
==94811== Command: ./test-fs
==94811==

[ . . . ]

==94811==
==94811== FILE DESCRIPTORS: 9 open at exit.
==94811== Open file descriptor 8: ./tmp/1
==94811==    at 0x2B3AFA: open$NOCANCEL (in /usr/lib/system/libsystem_kernel.dylib)
==94811==    by 0x1000009BC: fs_open (in ./test-fs)
==94811==    by 0x100000EC5: fs_nwrite (in ./test-fs)
==94811==    by 0x100000E8C: fs_write (in ./test-fs)
==94811==    by 0x10000169A: main (in ./test-fs)
==94811==
==94811== Open file descriptor 7: ./tmp/biz
==94811==    at 0x2B3AFA: open$NOCANCEL (in /usr/lib/system/libsystem_kernel.dylib)
==94811==    by 0x1000009BC: fs_open (in ./test-fs)
==94811==    by 0x100000D4B: fs_read (in ./test-fs)
==94811==    by 0x100001517: main (in ./test-fs)
==94811==
==94811== Open file descriptor 3: ./tmp/biz
==94811==    at 0x2B3AFA: open$NOCANCEL (in /usr/lib/system/libsystem_kernel.dylib)
==94811==    by 0x1000009BC: fs_open (in ./test-fs)
==94811==    by 0x100000EC5: fs_nwrite (in ./test-fs)
==94811==    by 0x100000E8C: fs_write (in ./test-fs)
==94811==    by 0x1000014FD: main (in ./test-fs)
==94811==
==94811== Open file descriptor 6: ./tmp/file
==94811==    at 0x2B3AFA: open$NOCANCEL (in /usr/lib/system/libsystem_kernel.dylib)
==94811==    by 0x1000009BC: fs_open (in ./test-fs)
==94811==    by 0x100000D4B: fs_read (in ./test-fs)
==94811==    by 0x100001240: main (in ./test-fs)
==94811==
==94811== Open file descriptor 5: ./tmp/file.link
==94811==    at 0x2B3AFA: open$NOCANCEL (in /usr/lib/system/libsystem_kernel.dylib)
==94811==    by 0x1000009BC: fs_open (in ./test-fs)
==94811==    by 0x100000D4B: fs_read (in ./test-fs)
==94811==    by 0x100001230: main (in ./test-fs)
==94811==
==94811== Open file descriptor 4: ./tmp/file
==94811==    at 0x2B3AFA: open$NOCANCEL (in /usr/lib/system/libsystem_kernel.dylib)
==94811==    by 0x1000009BC: fs_open (in ./test-fs)
==94811==    by 0x100000D4B: fs_read (in ./test-fs)
==94811==    by 0x1000011D1: main (in ./test-fs)
==94811==
==94811== Open file descriptor 2: /dev/ttys003
==94811==    <inherited from parent>
==94811==
==94811== Open file descriptor 1: /dev/ttys003
==94811==    <inherited from parent>
==94811==
==94811== Open file descriptor 0: /dev/ttys003
==94811==    <inherited from parent>
==94811==

[ . . . ]
```

after:

```
$ valgrind --track-fds=yes ./test-fs > after
==94851== Memcheck, a memory error detector
==94851== Copyright (C) 2002-2012, and GNU GPL'd, by Julian Seward et al.
==94851== Using Valgrind-3.8.1 and LibVEX; rerun with -h for copyright info
==94851== Command: ./test-fs

[ . . . ]

==94851== 
==96585== FILE DESCRIPTORS: 3 open at exit.
==96585== Open file descriptor 2: /dev/ttys003
==96585==    <inherited from parent>
==96585== 
==96585== Open file descriptor 1: /dev/ttys003
==96585==    <inherited from parent>
==96585== 
==96585== Open file descriptor 0: /dev/ttys003
==96585==    <inherited from parent>
==96585== 

[ . . . ]
```
