### PR TITLE
add `stdio.h` to prevent compilation failures

### DIFF
--- a/fs.h
+++ b/fs.h
@@ -10,6 +10,7 @@
  */
 
 
+#include <stdio.h>
 #include <sys/stat.h>
 
 typedef struct stat fs_stats;


### PR DESCRIPTION
prevents stuff like:

``` sh
./fs.h:32:1: error: unknown type name 'FILE'
FILE *
^
./fs.h:41:11: error: unknown type name 'FILE'
fs_close (FILE *file);
          ^
./fs.h:66:11: error: unknown type name 'FILE'
fs_fstat (FILE *file);
          ^
./fs.h:83:15: error: unknown type name 'FILE'
fs_ftruncate (FILE *file, int len);
              ^
./fs.h:112:12: error: unknown type name 'FILE'
fs_fchown (FILE *file, int uid, int gid);
           ^
./fs.h:120:1: error: unknown type name 'size_t'; did you mean 'time_t'?
```

when your source file doesn't include `stdio.h`
