### PR TITLE
Fix name in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "fs.c",
+  "name": "fs",
   "version": "0.0.1",
   "description": "File system API much like Node's fs module",
   "repo": "jwerle/fs.c",


### PR DESCRIPTION
Soon-ish, clib-install(1) will be installing packages into their own subdirectories.  This change allows us to `#import "fs/fs.h"` rather than `#import "fs.c/fs.h"`.
