### PR TITLE
fs_fnread: cut buffer using actual read size

### DIFF
--- a/fs.c
+++ b/fs.c
@@ -196,8 +196,8 @@ fs_fread (FILE *file) {
 char *
 fs_fnread (FILE *file, int len) {
   char *buffer = (char*) malloc(sizeof(char) * (len + 1));
-  fread(buffer, 1, len, file);
-  buffer[len] = '\0';
+  size_t n = fread(buffer, 1, len, file);
+  buffer[n] = '\0';
   return buffer;
 }
 


### PR DESCRIPTION
Avoid uninitialized string buffer when the file is smaller than `len` passed to `fs_nread` and `fs_fnread`.
