### PR TITLE
Allow linker to locate lstat using -D_BSD_SOURCE

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@
 AR ?= ar
 CC ?= gcc
 PREFIX ?= /usr/local
-CFLAGS = -std=c99 -Wall -Wextra -U__STRICT_ANSI__
+CFLAGS = -std=c99 -Wall -Wextra -D_BSD_SOURCE
 
 SRC = fs.c
 HEADERS = fs.h


### PR DESCRIPTION
This unbreaks the build on OpenBSD

Unsetting __STRICT_ANSI__ does not always allow non-POSIX library
functions to be visible when using -std=c99. _BSD_SOURCE means "use C99
but give me access to modern libc"